### PR TITLE
Convert camelcase to snake case for consistency

### DIFF
--- a/lib/relay.js
+++ b/lib/relay.js
@@ -85,11 +85,11 @@ async function reconnect(me)
 	}
 }
 
-Relay.prototype.on = function relayOn(method, fn) {
+Relay.prototype.on = function relay_on(method, fn) {
 	this.onfn[method] = fn
 }
 
-Relay.prototype.close = function relayClose() {
+Relay.prototype.close = function relay_on() {
 	if (this.ws) {
 		this.manualClose = true
 		this.ws.close()


### PR DESCRIPTION
Housekeeping, all other prototype declarations were snakecase. 